### PR TITLE
Feature/lockonchangestatus

### DIFF
--- a/src/main/java/se/moadb/recruitserver/application/ConcurrentAccessException.java
+++ b/src/main/java/se/moadb/recruitserver/application/ConcurrentAccessException.java
@@ -1,0 +1,26 @@
+package se.moadb.recruitserver.application;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception when trying to change an entity which is being changed by someone else at the same time.
+ */
+@ResponseStatus(value=HttpStatus.CONFLICT)
+public class ConcurrentAccessException extends RuntimeException {
+   public ConcurrentAccessException() {
+      super("You tried to access a resource that was being accessed simultaneously by another user, which is not allowed.");
+   }
+   public ConcurrentAccessException(String table, String key) {
+      super(createMessage(table, key));
+   }
+   private static String createMessage(String table, String key) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("You tried to access the key '");
+      sb.append(key);
+      sb.append("' in the table '");
+      sb.append(table.toString());
+      sb.append("' at the same time another user was updating it. This is not allowed, and your transaction was aborted.");
+      return sb.toString();
+   }
+}

--- a/src/main/java/se/moadb/recruitserver/application/DataLoader.java
+++ b/src/main/java/se/moadb/recruitserver/application/DataLoader.java
@@ -69,7 +69,7 @@ public class DataLoader implements ApplicationRunner {
         //Reads value from environment variable which can be set in Travis and Heroku if migration is wanted.
         String migrate = System.getenv("MIGRATE");
         //migrate = "TRUE";
-        migrate = "FALSE";
+        //migrate = "FALSE";
 
         if(migrate.equals("TRUE")){
             runSqlFromFile("oldDB.sql");

--- a/src/main/java/se/moadb/recruitserver/domain/Application.java
+++ b/src/main/java/se/moadb/recruitserver/domain/Application.java
@@ -1,9 +1,11 @@
 package se.moadb.recruitserver.domain;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import javax.persistence.*;
 import java.sql.Date;
+import java.sql.Timestamp;
 import java.util.Collection;
 
 @Entity
@@ -28,53 +30,76 @@ public class Application {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private Date date;
 
-    public Application() {
-    }
+    //enables optimistic locking. that is, if two users/threads concurrently try to operate on an instance of application, it will use this timestamp to decide if the row was changed while our transcation was going on
+    //if such is the case, it will throw OptimisticLockException
+    @JsonIgnore
+    @Version
+    private Timestamp changed;
 
-    public Application(Person person, Collection<CompetenceProfile> competenceProfiles, Collection<Availability> availabilities, Status status, Date date) {
-        this.person = person;
-        this.competenceProfiles = competenceProfiles;
-        this.availabilities = availabilities;
-        this.status = status;
-        this.date = date;
-    }
-    public long getId() {
-        return id;
-    }
 
-    public void setId(long id) {
-        this.id = id;
-    }
+   public Date getDate() {
+      return date;
+   }
 
-    public Person getPerson() {
-        return person;
-    }
+   public void setDate(Date date) {
+      this.date = date;
+   }
 
-    public void setPerson(Person person) {
-        this.person = person;
-    }
+   public Timestamp getChanged() {
+      return changed;
+   }
 
-    public Collection<CompetenceProfile> getCompetenceProfiles() {
-        return competenceProfiles;
-    }
+   public void setChanged(Timestamp changed) {
+      this.changed = changed;
+   }
 
-    public void setCompetenceProfiles(Collection<CompetenceProfile> competenceProfiles) {
-        this.competenceProfiles = competenceProfiles;
-    }
+   public Application() {
+   }
 
-    public Collection<Availability> getAvailabilities() {
-        return availabilities;
-    }
+   public Application(Person person, Collection<CompetenceProfile> competenceProfiles, Collection<Availability> availabilities, Status status, Date date) {
+      this.person = person;
+      this.competenceProfiles = competenceProfiles;
+      this.availabilities = availabilities;
+      this.status = status;
+      this.date = date;
+   }
+   public long getId() {
+      return id;
+   }
 
-    public void setAvailabilities(Collection<Availability> availabilities) {
-        this.availabilities = availabilities;
-    }
+   public void setId(long id) {
+      this.id = id;
+   }
 
-    public Status getStatus() {
-        return status;
-    }
+   public Person getPerson() {
+      return person;
+   }
 
-    public void setStatus(Status status) {
-        this.status = status;
-    }
+   public void setPerson(Person person) {
+      this.person = person;
+   }
+
+   public Collection<CompetenceProfile> getCompetenceProfiles() {
+      return competenceProfiles;
+   }
+
+   public void setCompetenceProfiles(Collection<CompetenceProfile> competenceProfiles) {
+      this.competenceProfiles = competenceProfiles;
+   }
+
+   public Collection<Availability> getAvailabilities() {
+      return availabilities;
+   }
+
+   public void setAvailabilities(Collection<Availability> availabilities) {
+      this.availabilities = availabilities;
+   }
+
+   public Status getStatus() {
+      return status;
+   }
+
+   public void setStatus(Status status) {
+      this.status = status;
+   }
 }

--- a/src/main/java/se/moadb/recruitserver/domain/Status.java
+++ b/src/main/java/se/moadb/recruitserver/domain/Status.java
@@ -6,6 +6,11 @@ import javax.persistence.Id;
 @Entity
 public class Status {
 
+    //constants, should reflect what is in database
+    public static final String ACCEPTED = "ACCEPTED";
+    public static final String REJECTED = "REJECTED";
+    public static final String UNHANDLED = "UNHANDLED";
+
     @Id
     private String name;
 

--- a/src/main/java/se/moadb/recruitserver/presentation/ApplicationController.java
+++ b/src/main/java/se/moadb/recruitserver/presentation/ApplicationController.java
@@ -69,25 +69,31 @@ public class ApplicationController {
 
    /**
     * Change status of an application to "accepted"
+    * @throws se.moadb.recruitserver.application.ConcurrentAccessException: HTTP 409: Conflict, if accessing an application that was simultaneously altered by another user.
     */
    @PutMapping("/{id}/accept")
-   public Application acceptApplication(@PathVariable long id) {
-      return applicationService.accept(id);
+   public Application acceptApplication(@PathVariable long id, @RequestBody ApplicationStatusPutRequest applicationStatusPutRequest) {
+      String oldStatusToCompareWith = applicationStatusPutRequest.getStatus();
+      return applicationService.accept(id, oldStatusToCompareWith);
    }
 
    /**
     * Change status of an application to "rejected"
+    * @throws se.moadb.recruitserver.application.ConcurrentAccessException: HTTP 409: Conflict, if accessing an application that was simultaneously altered by another user.
     */
    @PutMapping("/{id}/reject")
-   public Application rejectApplication(@PathVariable long id) {
-      return applicationService.reject(id);
+   public Application rejectApplication(@PathVariable long id, @RequestBody ApplicationStatusPutRequest applicationStatusPutRequest) {
+      String oldStatusToCompareWith = applicationStatusPutRequest.getStatus();
+      return applicationService.reject(id, oldStatusToCompareWith);
    }
 
    /**
     * Change status of an application to "unhandled"
+    * @throws se.moadb.recruitserver.application.ConcurrentAccessException: HTTP 409: Conflict, if accessing an application that was simultaneously altered by another user.
     */
    @PutMapping("/{id}/unhandle")
-   public Application unhandleApplication(@PathVariable long id) {
-      return applicationService.unhandle(id);
+   public Application unhandleApplication(@PathVariable long id, @RequestBody ApplicationStatusPutRequest applicationStatusPutRequest) {
+      String oldStatusToCompareWith = applicationStatusPutRequest.getStatus();
+      return applicationService.unhandle(id, oldStatusToCompareWith);
    }
 }

--- a/src/main/java/se/moadb/recruitserver/presentation/ApplicationStatusPutRequest.java
+++ b/src/main/java/se/moadb/recruitserver/presentation/ApplicationStatusPutRequest.java
@@ -1,0 +1,23 @@
+package se.moadb.recruitserver.presentation;
+
+/**
+ * Represents a JSON PUT request to change a status, to /accept, /reject, or /unhandled
+ */
+public class ApplicationStatusPutRequest {
+   private String status;
+
+   public ApplicationStatusPutRequest() {
+
+   }
+   public ApplicationStatusPutRequest(String status) {
+      this.status = status;
+   }
+
+   public String getStatus() {
+      return status;
+   }
+
+   public void setStatus(String status) {
+      this.status = status;
+   }
+}

--- a/src/test/java/se/moadb/recruitserver/application/ApplicationServiceTest.java
+++ b/src/test/java/se/moadb/recruitserver/application/ApplicationServiceTest.java
@@ -96,7 +96,7 @@ public class ApplicationServiceTest {
       Mockito.when(statusRepository.findByName("UNHANDLED")).thenReturn(new Status("UNHANDLED"));
       Mockito.when(applicationRepository.findById((long) 1)).thenReturn(java.util.Optional.ofNullable(accepted));
       Mockito.when(applicationRepository.save(any(Application.class))).thenReturn(unhandledapp);
-      Application result = applicationService.unhandle(1);
+      Application result = applicationService.unhandle(1, Status.ACCEPTED);
       Assert.assertEquals(expected, result);
 
    }
@@ -105,7 +105,7 @@ public class ApplicationServiceTest {
       Mockito.when(statusRepository.findByName("UNHANDLED")).thenReturn(new Status("UNHANDLED"));
       Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(null));
 
-      applicationService.accept(10);
+      applicationService.accept(10, Status.UNHANDLED);
    }
    @Test
    public void accept_shouldReturnAcceptedApp() throws Exception {
@@ -116,7 +116,7 @@ public class ApplicationServiceTest {
       Mockito.when(statusRepository.findByName("ACCEPTED")).thenReturn(new Status("ACCEPTED"));
       Mockito.when(applicationRepository.findById((long) 1)).thenReturn(java.util.Optional.ofNullable(unhandled));
       Mockito.when(applicationRepository.save(any(Application.class))).thenReturn(acceptedapp);
-      Application result = applicationService.accept(1);
+      Application result = applicationService.accept(1, Status.UNHANDLED);
       Assert.assertEquals(expected, result);
    }
    @Test(expected = EntityDoesNotExistException.class)
@@ -124,7 +124,7 @@ public class ApplicationServiceTest {
       Mockito.when(statusRepository.findByName("ACCEPTED")).thenReturn(new Status("ACCEPTED"));
       Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(null));
 
-      applicationService.accept(10);
+      applicationService.accept(10, Status.UNHANDLED);
    }
    @Test
    public void reject_shouldReturnRejectedApp() throws Exception {
@@ -135,7 +135,7 @@ public class ApplicationServiceTest {
       Mockito.when(statusRepository.findByName("REJECTED")).thenReturn(new Status("REJECTED"));
       Mockito.when(applicationRepository.findById((long) 1)).thenReturn(java.util.Optional.ofNullable(unhandled));
       Mockito.when(applicationRepository.save(any(Application.class))).thenReturn(rejectedapp);
-      Application result = applicationService.accept(1);
+      Application result = applicationService.accept(1, Status.UNHANDLED);
       Assert.assertEquals(expected, result);
    }
    @Test(expected = EntityDoesNotExistException.class)
@@ -143,7 +143,7 @@ public class ApplicationServiceTest {
       Mockito.when(statusRepository.findByName("REJECTED")).thenReturn(new Status("REJECTED"));
       Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(null));
 
-      applicationService.accept(10);
+      applicationService.reject(10, Status.UNHANDLED);
    }
    @Test
    public void saveapplication_shouldReturnSavedApplication() throws Exception {
@@ -220,7 +220,7 @@ public class ApplicationServiceTest {
       Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(a));
       Mockito.when(applicationRepository.save(a)).thenThrow(new OptimisticLockException());
 
-      applicationService.accept(10);
+      applicationService.accept(10, Status.UNHANDLED);
    }
    @Test(expected = ConcurrentAccessException.class)
    public void rejectOnLockedApplication_shouldThrowException() throws Exception {
@@ -229,7 +229,7 @@ public class ApplicationServiceTest {
       Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(a));
       Mockito.when(applicationRepository.save(a)).thenThrow(new OptimisticLockException());
 
-      applicationService.reject(10);
+      applicationService.reject(10, Status.UNHANDLED);
    }
    @Test(expected = ConcurrentAccessException.class)
    public void unhandleOnLockedApplication_shouldThrowException() throws Exception {
@@ -238,6 +238,6 @@ public class ApplicationServiceTest {
       Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(a));
       Mockito.when(applicationRepository.save(a)).thenThrow(new OptimisticLockException());
 
-      applicationService.unhandle(10);
+      applicationService.unhandle(10, Status.ACCEPTED);
    }
 }

--- a/src/test/java/se/moadb/recruitserver/application/ApplicationServiceTest.java
+++ b/src/test/java/se/moadb/recruitserver/application/ApplicationServiceTest.java
@@ -18,6 +18,7 @@ import se.moadb.recruitserver.repository.CompetenceRepository;
 import se.moadb.recruitserver.repository.PersonRepository;
 import se.moadb.recruitserver.repository.StatusRepository;
 
+import javax.persistence.OptimisticLockException;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -211,5 +212,32 @@ public class ApplicationServiceTest {
       Mockito.when(securityService.getUser(username)).thenReturn(user);
       Mockito.when(personRepository.findByUser(user)).thenReturn(null);
       applicationService.saveApplication(apr, username);
+   }
+   @Test(expected = ConcurrentAccessException.class)
+   public void acceptOnLockedApplication_shouldThrowException() throws Exception {
+      Mockito.when(statusRepository.findByName(Status.ACCEPTED)).thenReturn(new Status(Status.ACCEPTED));
+      Application a = acceptedapp;
+      Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(a));
+      Mockito.when(applicationRepository.save(a)).thenThrow(new OptimisticLockException());
+
+      applicationService.accept(10);
+   }
+   @Test(expected = ConcurrentAccessException.class)
+   public void rejectOnLockedApplication_shouldThrowException() throws Exception {
+      Mockito.when(statusRepository.findByName(Status.REJECTED)).thenReturn(new Status(Status.REJECTED));
+      Application a = rejectedapp;
+      Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(a));
+      Mockito.when(applicationRepository.save(a)).thenThrow(new OptimisticLockException());
+
+      applicationService.reject(10);
+   }
+   @Test(expected = ConcurrentAccessException.class)
+   public void unhandleOnLockedApplication_shouldThrowException() throws Exception {
+      Mockito.when(statusRepository.findByName(Status.UNHANDLED)).thenReturn(new Status(Status.UNHANDLED));
+      Application a = unhandledapp;
+      Mockito.when(applicationRepository.findById((long) 10)).thenReturn(Optional.ofNullable(a));
+      Mockito.when(applicationRepository.save(a)).thenThrow(new OptimisticLockException());
+
+      applicationService.unhandle(10);
    }
 }

--- a/src/test/java/se/moadb/recruitserver/presentation/ApplicationControllerTest.java
+++ b/src/test/java/se/moadb/recruitserver/presentation/ApplicationControllerTest.java
@@ -49,6 +49,7 @@ public class ApplicationControllerTest {
    private Collection<Availability> availabilities;
    private Status status;
    private ApplicationPostRequest apr;
+   private ApplicationStatusPutRequest applicationStatusPutRequest;
    private String username;
    private Date appDate;
 
@@ -98,6 +99,7 @@ public class ApplicationControllerTest {
       la.add(aipr2);
       apr = new ApplicationPostRequest(lc, la);
 
+      applicationStatusPutRequest = new ApplicationStatusPutRequest(Status.ACCEPTED);
    }
 
    @Test
@@ -105,9 +107,12 @@ public class ApplicationControllerTest {
       long id = 1;
       Application a = new Application(p, competenceProfiles, availabilities, new Status("ACCEPTED"), appDate);
       a.setId(1);
-      Mockito.when(applicationService.accept(id)).thenReturn(a);
+      Mockito.when(applicationService.accept(id, Status.ACCEPTED)).thenReturn(a);
 
-      RequestBuilder rb = MockMvcRequestBuilders.put("/applications/1/accept").accept(MediaType.APPLICATION_JSON);
+      applicationStatusPutRequest.setStatus(Status.ACCEPTED);
+      RequestBuilder rb = MockMvcRequestBuilders.put("/applications/1/accept")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(applicationStatusPutRequest));
       MvcResult res = mvc.perform(rb).andReturn();
       String expected = "{ \"id\": 1, \"person\": { \"id\": 4, \"name\": \"Per\", \"surname\": \"Strand\", \"ssn\": \"19671212-1211\", \"email\": \"per@strand.kth.se\" }, \"competenceProfiles\": [ { \"id\": 7, \"competence\": { \"name\": \"Korvgrillning\" }, \"yearsOfExperience\": 3.5 }, { \"id\": 8, \"competence\": { \"name\": \"Karuselldrift\" }, \"yearsOfExperience\": 2 } ], \"availabilities\": [ { \"id\": 5, \"fromDate\": \"2014-02-23\", \"toDate\": \"2014-05-25\" }, { \"id\": 6, \"fromDate\": \"2014-07-10\", \"toDate\": \"2014-08-10\" } ], \"status\": { \"name\": \"ACCEPTED\" },\"date\":\"2013-05-04\" }";
       JSONAssert.assertEquals(expected, res.getResponse().getContentAsString(), true);
@@ -117,9 +122,12 @@ public class ApplicationControllerTest {
       long id = 1;
       Application a = new Application(p, competenceProfiles, availabilities, new Status("REJECTED"), appDate);
       a.setId(1);
-      Mockito.when(applicationService.reject(id)).thenReturn(a);
+      Mockito.when(applicationService.reject(id, Status.REJECTED)).thenReturn(a);
 
-      RequestBuilder rb = MockMvcRequestBuilders.put("/applications/1/reject").accept(MediaType.APPLICATION_JSON);
+      applicationStatusPutRequest.setStatus(Status.REJECTED);
+      RequestBuilder rb = MockMvcRequestBuilders.put("/applications/1/reject")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(applicationStatusPutRequest));
       MvcResult res = mvc.perform(rb).andReturn();
       String expected = "{ \"id\": 1, \"person\": { \"id\": 4, \"name\": \"Per\", \"surname\": \"Strand\", \"ssn\": \"19671212-1211\", \"email\": \"per@strand.kth.se\" }, \"competenceProfiles\": [ { \"id\": 7, \"competence\": { \"name\": \"Korvgrillning\" }, \"yearsOfExperience\": 3.5 }, { \"id\": 8, \"competence\": { \"name\": \"Karuselldrift\" }, \"yearsOfExperience\": 2 } ], \"availabilities\": [ { \"id\": 5, \"fromDate\": \"2014-02-23\", \"toDate\": \"2014-05-25\" }, { \"id\": 6, \"fromDate\": \"2014-07-10\", \"toDate\": \"2014-08-10\" } ], \"status\": { \"name\": \"REJECTED\" },\"date\":\"2013-05-04\"} }";
       JSONAssert.assertEquals(expected, res.getResponse().getContentAsString(), true);
@@ -130,9 +138,12 @@ public class ApplicationControllerTest {
       long id = 1;
       Application a = new Application(p, competenceProfiles, availabilities, new Status("UNHANDLED"), appDate);
       a.setId(1);
-      Mockito.when(applicationService.unhandle(id)).thenReturn(a);
+      Mockito.when(applicationService.unhandle(id, Status.UNHANDLED)).thenReturn(a);
 
-      RequestBuilder rb = MockMvcRequestBuilders.put("/applications/1/unhandle").accept(MediaType.APPLICATION_JSON);
+      applicationStatusPutRequest.setStatus(Status.UNHANDLED);
+      RequestBuilder rb = MockMvcRequestBuilders.put("/applications/1/unhandle")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(applicationStatusPutRequest));
       MvcResult res = mvc.perform(rb).andReturn();
       String expected = "{ \"id\": 1, \"person\": { \"id\": 4, \"name\": \"Per\", \"surname\": \"Strand\", \"ssn\": \"19671212-1211\", \"email\": \"per@strand.kth.se\" }, \"competenceProfiles\": [ { \"id\": 7, \"competence\": { \"name\": \"Korvgrillning\" }, \"yearsOfExperience\": 3.5 }, { \"id\": 8, \"competence\": { \"name\": \"Karuselldrift\" }, \"yearsOfExperience\": 2 } ], \"availabilities\": [ { \"id\": 5, \"fromDate\": \"2014-02-23\", \"toDate\": \"2014-05-25\" }, { \"id\": 6, \"fromDate\": \"2014-07-10\", \"toDate\": \"2014-08-10\" } ], \"status\": { \"name\": \"UNHANDLED\" },\"date\":\"2013-05-04\"} }";
       JSONAssert.assertEquals(expected, res.getResponse().getContentAsString(), true);


### PR DESCRIPTION
Implemented:
- Optimistic locking when changing an Application entity (f.e its status)
- Exception thrown to client (HTTP 409 : Conflict) when trying to change the status of an application, and the application was changed in between the client reading and trying to update the application - by another recruiter.